### PR TITLE
Minor code cleanups and custom auth guard additions

### DIFF
--- a/config/sentinel.php
+++ b/config/sentinel.php
@@ -15,6 +15,7 @@ return [
         'login' => null,
         'two-factor' => null,
     ],
+    'login_pipeline' => [],
     'stateful' => explode(',', env(
         'STATEFUL_DOMAINS',
         'preflight.test,localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1'

--- a/src/Actions/ConfirmPassword.php
+++ b/src/Actions/ConfirmPassword.php
@@ -18,8 +18,11 @@ class ConfirmPassword implements ConfirmsPasswords
      *
      * @return bool
      */
-    public function confirm(StatefulGuard $guard, Authenticatable $user, ?string $password = null): bool
-    {
+    public function confirm(
+        StatefulGuard $guard,
+        Authenticatable $user,
+        ?string $password = null
+    ): bool {
         $username = Config::username(['email']);
 
         return $guard->validate([

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Foundation\Auth\User;
 use Cratespace\Sentinel\Codes\RecoveryCode;
 use Cratespace\Sentinel\Events\TwoFactorAuthenticationEnabled;
-use Cratespace\Sentinel\Contracts\Providers\TwoFactorAuthenticationProvider;
+use Cratespace\Sentinel\Contracts\Actions\ProvidesTwoFactorAuthentication;
 
 class EnableTwoFactorAuthentication
 {
@@ -20,18 +20,18 @@ class EnableTwoFactorAuthentication
     /**
      * The two factor authentication provider.
      *
-     * @var \Sentinel\Contracts\Providers\TwoFactorAuthenticationProvider
+     * @var \Cratespace\Sentinel\Contracts\Actions\ProvidesTwoFactorAuthentication
      */
     protected $provider;
 
     /**
      * Create a new action instance.
      *
-     * @param \Sentinel\Contracts\Providers\TwoFactorAuthenticationProvider $provider
+     * @param \Cratespace\Sentinel\Contracts\Actions\ProvidesTwoFactorAuthentication $provider
      *
      * @return void
      */
-    public function __construct(TwoFactorAuthenticationProvider $provider)
+    public function __construct(ProvidesTwoFactorAuthentication $provider)
     {
         $this->provider = $provider;
     }

--- a/src/Actions/GenerateNewRecoveryCodes.php
+++ b/src/Actions/GenerateNewRecoveryCodes.php
@@ -2,21 +2,21 @@
 
 namespace Cratespace\Sentinel\Actions;
 
-use Cratespace\Sentinel\Codes\RecoveryCode;
 use Illuminate\Support\Collection;
+use Illuminate\Foundation\Auth\User;
+use Cratespace\Sentinel\Codes\RecoveryCode;
 use Cratespace\Sentinel\Events\RecoveryCodesGenerated;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 class GenerateNewRecoveryCodes
 {
     /**
      * Generate new recovery codes for the user.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param \Illuminate\Foundation\Auth\User $user
      *
      * @return void
      */
-    public function __invoke(Authenticatable $user): void
+    public function __invoke(User $user): void
     {
         $user->forceFill(['two_factor_recovery_codes' => $this->generateCode()])->save();
 

--- a/src/Actions/ProvideTwoFactorAuthentication.php
+++ b/src/Actions/ProvideTwoFactorAuthentication.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Cratespace\Sentinel\Providers;
+namespace Cratespace\Sentinel\Actions;
 
 use PragmaRX\Google2FA\Google2FA;
-use Cratespace\Sentinel\Contracts\Providers\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
+use Cratespace\Sentinel\Contracts\Actions\ProvidesTwoFactorAuthentication;
 
-class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProviderContract
+class ProvideTwoFactorAuthentication implements ProvidesTwoFactorAuthentication
 {
     /**
      * The underlying library providing two factor authentication helper services.

--- a/src/Contracts/Actions/ProvidesTwoFactorAuthentication.php
+++ b/src/Contracts/Actions/ProvidesTwoFactorAuthentication.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Cratespace\Sentinel\Contracts\Providers;
+namespace Cratespace\Sentinel\Contracts\Actions;
 
-interface TwoFactorAuthenticationProvider
+interface ProvidesTwoFactorAuthentication
 {
     /**
      * Generate a new secret key.

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -48,9 +48,9 @@ class TwoFactorAuthenticationController extends Controller
      *
      * @param \Sentinel\Http\Requests\TwoFactorLoginRequest $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return mixed
      */
-    public function store(TwoFactorLoginRequest $request): Response
+    public function store(TwoFactorLoginRequest $request)
     {
         $user = $request->challengedUser();
 

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -5,10 +5,12 @@ namespace Cratespace\Sentinel\Http\Requests;
 use Cratespace\Sentinel\Sentinel\Config;
 use Illuminate\Foundation\Http\FormRequest;
 use Cratespace\Sentinel\Http\Requests\Concerns\AuthorizesRequests;
+use Cratespace\Sentinel\Http\Requests\Traits\InputValidationRules;
 
 class LoginRequest extends FormRequest
 {
     use AuthorizesRequests;
+    use InputValidationRules;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -29,14 +31,12 @@ class LoginRequest extends FormRequest
     {
         $username = Config::username();
 
-        return [
+        return $this->getRulesFor('login', [
             $username => [
                 'required',
                 'string',
                 $username === 'email' ? 'email' : null,
             ],
-            'password' => ['required', 'string'],
-            'remember' => ['nullable'],
-        ];
+        ]);
     }
 }

--- a/src/Models/Traits/TwoFactorAuthenticatable.php
+++ b/src/Models/Traits/TwoFactorAuthenticatable.php
@@ -9,7 +9,7 @@ use Cratespace\Sentinel\Codes\RecoveryCode;
 use BaconQrCode\Renderer\RendererStyle\Fill;
 use BaconQrCode\Renderer\Image\SvgImageBackEnd;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
-use Cratespace\Sentinel\Contracts\Providers\TwoFactorAuthenticationProvider;
+use Cratespace\Sentinel\Contracts\Actions\ProvidesTwoFactorAuthentication;
 
 trait TwoFactorAuthenticatable
 {
@@ -75,7 +75,7 @@ trait TwoFactorAuthenticatable
      */
     public function twoFactorQrCodeUrl(): string
     {
-        return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
+        return app(ProvidesTwoFactorAuthentication::class)->qrCodeUrl(
             config('app.name'),
             $this->email,
             decrypt($this->two_factor_secret)

--- a/src/Providers/Traits/HasActions.php
+++ b/src/Providers/Traits/HasActions.php
@@ -16,7 +16,9 @@ trait HasActions
         }
 
         collect($this->actions)->each(
-            fn ($concrete, $abstract) => $this->app->singleton($abstract, $concrete)
+            function (string $concrete, string $abstract): void {
+                $this->app->singleton($abstract, $concrete);
+            }
         );
     }
 }

--- a/stubs/app/Actions/Auth/CreateNewUser.php
+++ b/stubs/app/Actions/Auth/CreateNewUser.php
@@ -2,7 +2,6 @@
 
 namespace App\Actions\Auth;
 
-use Closure;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
@@ -13,13 +12,6 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableUser;
 class CreateNewUser implements CreatesNewUsers
 {
     /**
-     * Callback that will be executed after a user has been created.
-     *
-     * @var \Closure|null
-     */
-    protected static $afterCreatingUser;
-
-    /**
      * Create a newly registered user.
      *
      * @param array $data
@@ -29,11 +21,7 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $data): AuthenticatableUser
     {
         return DB::transaction(function () use ($data) {
-            return tap($this->createUser($data), function (AuthenticatableUser $user) use ($data) {
-                if (static::$afterCreatingUser) {
-                    call_user_func_array(static::$afterCreatingUser, [$user, $data]);
-                }
-
+            return tap($this->createUser($data), function (AuthenticatableUser $user) {
                 return $user;
             });
         });
@@ -72,17 +60,5 @@ class CreateNewUser implements CreatesNewUsers
         }
 
         return Str::studly($name);
-    }
-
-    /**
-     * Register a callback that will be executed after a user has been created.
-     *
-     * @param \Closure|null $callback
-     *
-     * @return void
-     */
-    public static function afterCreatingUser(?Closure $callback = null): void
-    {
-        static::$afterCreatingUser = $callback;
     }
 }

--- a/stubs/config/rules.php
+++ b/stubs/config/rules.php
@@ -14,7 +14,7 @@ return [
      * User Login Validation Rules.
      */
     'login' => [
-        'email' => ['required', 'string', 'email'],
+        'email' => ['sometimes', 'string', 'email'],
         'password' => ['required', 'string'],
         'remember' => ['sometimes'],
     ],

--- a/stubs/config/sentinel.php
+++ b/stubs/config/sentinel.php
@@ -45,6 +45,11 @@ return [
     ],
 
     /*
+     * Additional middelware type classes to run when attempting to authenticate user.
+     */
+    'login_pipeline' => [],
+
+    /*
      * Register View Routes.
      */
     'views' => true,


### PR DESCRIPTION
## Purpose

Enhancement of previous features.

## Approach

### Added
- Custom Sentinel auth guard.
- Two Factor Authentication Provider actions and contract
- Ability to add custom/additional login pipeline middleware.

### Changed
- Code cleanups
- Proper type hinting for closure functions
- Use custom Two Factor Authentication Provider actions and classes
- Use Sentinel auth guard instead of previous "web" guard
- Removed [afterCreatingUser] feature

## Learning

Since auth actions like `CreateNewUser` will be presented to the front application as stubs, users are free to modify the actions them selves and add additional methods like `afterCreatingUser`. So, having a method like that to be defined in the service provider seems redundant.